### PR TITLE
Overlap performance

### DIFF
--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -2838,18 +2839,73 @@ public abstract class SimpleEditor extends JPanel {
 			}*/
 
 
+						// Set is O(n log(n)) to traverse over and doesn't benefit from cache locality.
+						// we're doing a lot of iterating over the same collection here,
+						// so it makes sense to use a temporary array for cache locality and O(n) traversal.
+						Element[] selectedArr = selected.toArray(Element[]::new);
+						ArrayList<Element> elementsArr = new ArrayList(circuit.getElements());
+						// elementsArr.removeAll(selected);
+						{
+							int i = 0;
+							while (i < elementsArr.size()) {
+								if (selected.contains(elementsArr.get(i))) {
+									// "swap" remove - slightly cheaper because we don't care about order
+									elementsArr.set(i, elementsArr.get(elementsArr.size() - 1));
+									elementsArr.remove(elementsArr.size() - 1); // pop
+									// don't increment on erase because [i] now refers to a new element
+								}
+								else {
+									i++;
+								}
+							}
+						}
+
+						// bounding box just adds a redundant step if selection is 1
+						if (selected.size() > 1) {
+							int xmin = Integer.MAX_VALUE;
+							int xmax = Integer.MIN_VALUE;
+							int ymin = Integer.MAX_VALUE;
+							int ymax = Integer.MIN_VALUE;
+
+							// build up a bounding box
+							for (Element sel : selectedArr) {
+								xmin = Math.min(xmin, sel.getX());
+								xmax = Math.max(xmax, sel.getX() + sel.getWidth());
+								ymin = Math.min(ymin, sel.getY());
+								ymax = Math.max(ymax, sel.getY() + sel.getHeight());
+							}
+
+							Rectangle bounds = new Rectangle(xmin, ymin, xmax - xmin, ymax - ymin);
+
+							// elementsArr.removeIf(el -> !el.isOverlapping(bounds));
+							{
+								int i = 0;
+								while (i < elementsArr.size()) {
+									if (!elementsArr.get(i).isOverlapping(bounds)) {
+										// "swap" remove - slightly cheaper because we don't care about order
+										elementsArr.set(i, elementsArr.get(elementsArr.size() - 1));
+										elementsArr.remove(elementsArr.size() - 1); // pop
+										// don't increment on erase because [i] now refers to a new element
+									}
+									else {
+										i++;
+									}
+								}
+							}
+						}
+						elementsArr.trimToSize();
+
 						// check every element in the selected set
-						for (Element sel : selected) {
+						for (Element sel : selectedArr) {
 
-							// check against every element in the circuit
-							for (Element el : circuit.getElements()) {
+							boolean anyIntersection = false;
 
-								// ignore elements in the selected set
-								if (selected.contains(el))
-									continue;
+							// check against every (unselected, bounds-overlapping) element in the circuit
+							for (Element el : elementsArr) {
 
 								// check simple overlap of areas
 								if (sel.intersects(el)) {
+									anyIntersection = true;
 
 									// no overlap if possible connection,
 									boolean ok = false;
@@ -2927,42 +2983,42 @@ public abstract class SimpleEditor extends JPanel {
 									// selected is not a wire end
 									else {
 
-										// put to wire end
-										for (Put put : sel.getAllPuts()) {
-
-											// if not a wire end, ignore
-											if (!(el instanceof WireEnd))
-												continue;
+										// if element is a wire end, ...
+										if (el instanceof WireEnd) {
 											WireEnd end = (WireEnd)el;
 
-											// if don't line up, ignore
-											if (put.getX() != end.getX() || put.getY() != end.getY()) {
-												continue;
-											}
+											// put to wire end
+											for (Put put : sel.getAllPuts()) {
 
-											// if already attached to this wire end, ignore
-											if (end == put.getWireEnd()) {
+												// if don't line up, ignore
+												if (put.getX() != end.getX() || put.getY() != end.getY()) {
+													continue;
+												}
+
+												// if already attached to this wire end, ignore
+												if (end == put.getWireEnd()) {
+													ok = true;
+													continue;
+												}
+
+												// if attached through a single wire, ignore
+												WireEnd putEnd = put.getWireEnd();
+												if (putEnd != null &&
+														putEnd.getOnlyWire().getOtherEnd(putEnd) == end) {
+													ok = true;
+													continue;
+												}
+
+												// if cannot connect, return
+												if (!canConnect(end,put)) {
+													untouchAll();
+													return true;
+												}
+
+												end.setTouching(true);
+												put.setTouching(true);
 												ok = true;
-												continue;
 											}
-
-											// if attached through a single wire, ignore
-											WireEnd putEnd = put.getWireEnd();
-											if (putEnd != null &&
-													putEnd.getOnlyWire().getOtherEnd(putEnd) == end) {
-												ok = true;
-												continue;
-											}
-
-											// if cannot connect, return
-											if (!canConnect(end,put)) {
-												untouchAll();
-												return true;
-											}
-
-											end.setTouching(true);
-											put.setTouching(true);
-											ok = true;
 										}
 									}
 									if (!ok) {
@@ -2971,52 +3027,50 @@ public abstract class SimpleEditor extends JPanel {
 										return true;
 									}
 								}
+							}
 
-								// no intersection, but wires may be overlapping wire ends
-								// or puts might line up
-								else {
+							// no intersection, but wires may be overlapping wire ends
+							// or puts might line up
+							if (!anyIntersection) {
 
-									// see if wires connected to a wire end dragged onto wire ends
-									if (sel instanceof WireEnd) {
-										WireEnd end = (WireEnd)sel;
-										for (Wire wire : end.getWires()) {
-											for (Element elm : circuit.getElements()) {
-												if (sel == elm)
-													continue;
-												if (!(elm instanceof WireEnd)) {
-													continue;
-												}
-												WireEnd otherEnd = (WireEnd)elm;
-												if (wire.touches(otherEnd)) {
-													overlapMessage = "overlap";
-													untouchAll();
-													return true;
-												}
+								// see if wires connected to a wire end dragged onto wire ends
+								if (sel instanceof WireEnd) {
+									WireEnd end = (WireEnd)sel;
+									for (Wire wire : end.getWires()) {
+										for (Element el : elementsArr) {
+											if (!(el instanceof WireEnd)) {
+												continue;
+											}
+											WireEnd otherEnd = (WireEnd)el;
+											if (wire.touches(otherEnd)) {
+												overlapMessage = "overlap";
+												untouchAll();
+												return true;
 											}
 										}
 									}
+								}
 
-									// see if wires connected to puts dragged onto wire ends
-									for (Put p : sel.getAllPuts()) {
-										if (p.isAttached()) {
-											Wire wire = p.getWireEnd().getOnlyWire();
-											for (Element elm : circuit.getElements()) {
-												if (sel == elm)
-													continue;
-												if (!(elm instanceof WireEnd)) {
-													continue;
-												}
-												WireEnd otherEnd = (WireEnd)elm;
-												if (wire.touches(otherEnd)) {
-													overlapMessage = "overlap";
-													untouchAll();
-													return true;
-												}
+								// see if wires connected to puts dragged onto wire ends
+								for (Put p : sel.getAllPuts()) {
+									if (p.isAttached()) {
+										Wire wire = p.getWireEnd().getOnlyWire();
+										for (Element el : elementsArr) {
+											if (!(el instanceof WireEnd)) {
+												continue;
+											}
+											WireEnd otherEnd = (WireEnd)el;
+											if (wire.touches(otherEnd)) {
+												overlapMessage = "overlap";
+												untouchAll();
+												return true;
 											}
 										}
 									}
+								}
 
-									// check all put combinations
+								// check all put combinations
+								for (Element el : elementsArr) {
 									for (Put p1 : sel.getAllPuts()) {
 										for (Put p2 : el.getAllPuts()) {
 
@@ -3028,7 +3082,7 @@ public abstract class SimpleEditor extends JPanel {
 											// ignore overlaps on already connected puts
 											WireEnd end1 = p1.getWireEnd();
 											WireEnd end2 = p2.getWireEnd();
-											if (end1 != null && end2 != null && 
+											if (end1 != null && end2 != null &&
 													end1.getOnlyWire().getOtherEnd(end1) == end2) {
 												continue;
 											}
@@ -3047,8 +3101,8 @@ public abstract class SimpleEditor extends JPanel {
 								}
 							}
 						}
-					repaint();
-					return false;
+						repaint();
+						return false;
 					} // end of overlap method
 
 					/**

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2862,47 +2862,12 @@ public abstract class SimpleEditor extends JPanel {
 							}
 						}
 
-						// bounding box just adds a redundant step if selection is 1
-						if (selected.size() > 1) {
-							int xmin = Integer.MAX_VALUE;
-							int xmax = Integer.MIN_VALUE;
-							int ymin = Integer.MAX_VALUE;
-							int ymax = Integer.MIN_VALUE;
-
-							// build up a bounding box
-							for (Element sel : selectedArr) {
-								xmin = Math.min(xmin, sel.getX());
-								xmax = Math.max(xmax, sel.getX() + sel.getWidth());
-								ymin = Math.min(ymin, sel.getY());
-								ymax = Math.max(ymax, sel.getY() + sel.getHeight());
-							}
-
-							Rectangle bounds = new Rectangle(xmin, ymin, xmax - xmin, ymax - ymin);
-
-							// elementsArr.removeIf(el -> !el.isOverlapping(bounds));
-							{
-								int i = 0;
-								while (i < elementsArr.size()) {
-									if (!elementsArr.get(i).isOverlapping(bounds)) {
-										// "swap" remove - slightly cheaper because we don't care about order
-										elementsArr.set(i, elementsArr.get(elementsArr.size() - 1));
-										elementsArr.remove(elementsArr.size() - 1); // pop
-										// don't increment on erase because [i] now refers to a new element
-									}
-									else {
-										i++;
-									}
-								}
-							}
-						}
-						elementsArr.trimToSize();
-
 						// check every element in the selected set
 						for (Element sel : selectedArr) {
 
 							boolean anyIntersection = false;
 
-							// check against every (unselected, bounds-overlapping) element in the circuit
+							// check against every unselected element in the circuit
 							for (Element el : elementsArr) {
 
 								// check simple overlap of areas

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2842,8 +2842,8 @@ public abstract class SimpleEditor extends JPanel {
 						// Set is O(n log(n)) to traverse over and doesn't benefit from cache locality.
 						// we're doing a lot of iterating over the same collection here,
 						// so it makes sense to use a temporary array for cache locality and O(n) traversal.
-						Element[] selectedArr = selected.toArray(Element[]::new);
-						ArrayList<Element> elementsArr = new ArrayList(circuit.getElements());
+						Element[] selectedArr = selected.toArray(new Element[selected.size()]);
+						ArrayList<Element> elementsArr = new ArrayList<Element>(circuit.getElements());
 						// elementsArr.removeAll(selected);
 						{
 							int i = 0;

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2839,6 +2839,8 @@ public abstract class SimpleEditor extends JPanel {
 			}*/
 
 
+						untouchAll(); // may have moved and stopped touching
+
 						// Set is O(n log(n)) to traverse over and doesn't benefit from cache locality.
 						// we're doing a lot of iterating over the same collection here,
 						// so it makes sense to use a temporary array for cache locality and O(n) traversal.

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -114,6 +114,26 @@ public class Element {
 
 		return y;
 	} // end of getY method
+
+	/**
+	 * Get width of this element.
+	 *
+	 * @return the width.
+	 */
+	public int getWidth() {
+
+		return width;
+	} // end of getWidth method
+
+	/**
+	 * Get height of this element.
+	 *
+	 * @return the height.
+	 */
+	public int getHeight() {
+
+		return height;
+	} // end of getHeight method
 	
 	/**
 	 * Get the trace position of this element.
@@ -327,6 +347,19 @@ public class Element {
 		Rectangle me = getRect();
 		return rect.contains(me);
 	} // end of isInside method
+
+	/**
+	 * See if this element is intersecting a given rectangle.
+	 *
+	 * @param rect The given rectangle.
+	 *
+	 * @return true if the element is intersecting, false if not.
+	 */
+	public boolean isOverlapping(Rectangle rect) {
+
+		Rectangle me = getRect();
+		return rect.intersects(me);
+	} // end of isOverlapping method
 
 	/**
 	 * Set/reset highlight.


### PR DESCRIPTION
(Copied from [PR 4 on anadon's repo](https://github.com/anadon/JLS/pull/4))

- Copy element `Set`s to temporary arrays and `ArrayList`s, since they will be iterated over far more than they will be searched within the `overlap` method.
- Implement a bounding box for the selection and remove any elements not overlapping the bounding box from the temporary unselected element `ArrayList` before any further checks.
  - Use swap-removal since order doesn't matter, making the removal worst case $O(1)$ instead of $O(n)$
- Crunch the $O(n^3)$ section in the "else" case for simple intersections down to $O(n^2)$, since that part seems to just be checking against all elements per element per selected element--despite only involving the selected element and all other elements, not the selected element and all permutations of other elements.
  i.e.
```java
for (Element sel : selected) {          // O(n)
  for (Element el : elementsArr) {      // O(n^2)
    if (intersecting) { ... }
    else {
      for (Element elm : elementsArr) { // O(n^3)
        if (sel ? elm) // no mention of `el`
```
$$\large\Downarrow$$
```java
for (Element sel : selected) {       // O(n)
  for (Element el : elementsArr) {   // O(n^2)
    if (intersecting) { ... }
  }
  if (none intersected) {
    for (Element el : elementsArr) { // O(n^2)
      if (sel ? el) // ...
```