### PR TITLE
Allow wire to be started in spite of hover

### DIFF
--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -490,10 +490,11 @@ public abstract class SimpleEditor extends JPanel {
 						if (!enabled)
 							return;
 
-						// if nothing selected and current state is idle
-						if (selected.size() == 0 && currentState == State.idle) {
+						// if current state is idle
+						if (currentState == State.idle) {
 
 							// start a wire
+							clearSelected();
 							Point p = getMousePosition();
 							if (p == null)
 								return; // not in drawing window
@@ -509,6 +510,17 @@ public abstract class SimpleEditor extends JPanel {
 							net = new WireNet();
 							net.add(wireEnd);
 							wireEnd.setNet(net);
+							if (!selected.isEmpty()) {
+								// check for overlaps
+								if (overlap()) {
+									info.setText(overlapMessage);
+									info.setForeground(Color.red);
+								}
+								else {
+									info.setText("");
+									info.setForeground(Color.black);
+								}
+							}
 							repaint();
 						}
 						else if (selected.size() == 1){

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -494,6 +494,7 @@ public abstract class SimpleEditor extends JPanel {
 						if (currentState == State.idle) {
 
 							// start a wire
+							boolean hadSelection = !selected.isEmpty();
 							clearSelected();
 							Point p = getMousePosition();
 							if (p == null)
@@ -510,7 +511,7 @@ public abstract class SimpleEditor extends JPanel {
 							net = new WireNet();
 							net.add(wireEnd);
 							wireEnd.setNet(net);
-							if (!selected.isEmpty()) {
+							if (hadSelection) {
 								// check for overlaps
 								if (overlap()) {
 									info.setText(overlapMessage);


### PR DESCRIPTION
Wires are allowed to be connected to other wires and are allowed to overlap other elements before being confirmed. However, the wire creation action validates against this by refusing to create a wire if an element is currently hovered.

This makes wire construction a little unwieldy since it can only be performed over an empty grid space, which there may be few of on a dense circuit. I believe it would be ideal if the only limiting factors for initiating wire creation were the same limiting factors present *during* wire creation.
i.e. if you could do it *after* pressing ctrl+w, it should be allowed *while* pressing ctrl+w. That would be more intuitive, consistent, and ergonomic.