### PR TITLE
Fix HiZ bundles refusing to connect

### DIFF
--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2611,8 +2611,10 @@ public abstract class SimpleEditor extends JPanel {
 								norm = true;
 						}
 					}
-					if(end.isTriState()) tri = true;
-					else norm = true;
+					if (end.isAttached()) {
+						if(end.isTriState()) tri = true;
+						else norm = true;
+					}
 					if(tri && norm) {
 						overlapMessage = "Cannot connect both tri-state and normal wires to a bundle";
 						return false;


### PR DESCRIPTION
Fixes #19 

There is a check being applied to all the `put`s that wasn't being applied to the `end`. Without this check, the `end` would be treated as though it was definitely normal, despite wires unconnected wires lacking statefulness.