### PR TITLE
Fixed Crash on Missing Name & State of Fixed State Machine on Run.

### DIFF
--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -809,6 +809,7 @@ public final class StateMachine extends LogicElement implements Printable {
 		private Point movingPoint;
 		private boolean nameChange;
 		private StateMachine machine;
+		private boolean creating;
 
 		/**
 		 * Set up create dialog window.
@@ -824,6 +825,7 @@ public final class StateMachine extends LogicElement implements Printable {
 			// save reference to me
 			currentDialog = this;
 			this.machine = machine;
+			this.creating = creating;
 			
 			// set not canceled
 			canceled = false;
@@ -1057,6 +1059,20 @@ public final class StateMachine extends LogicElement implements Printable {
 				}
 				else {
 					nameChange = true;
+				}
+				if (creating) {
+					String message = "";
+					if (states.isEmpty() && name.trim().isEmpty()) {
+						message = "You need a name and at least one state.";
+					} else if (states.isEmpty()) {
+						message = "You need at least one state.";
+					} else if (name.trim().isEmpty()) {
+						message = "You need a name.";
+					}
+					if (!message.isEmpty()) {
+						JOptionPane.showMessageDialog(this, message, "Error", JOptionPane.ERROR_MESSAGE);
+						return;
+					}
 				}
 				dispose();
 			}


### PR DESCRIPTION
## Summary
fixes #24 

Adds validation for `StateMachine` elements before simulation begins to prevent the crash described in #24.

If a `StateMachine` is missing required information, a popup dialog is shown explaining the problem instead of allowing the simulator to start and fail later.

## Changes

* Added validation for `StateMachine` configuration.
* Displays a popup if the state machine:

  * has no name
  * has no states
  * has neither a name nor states
* Prevents the simulator from starting until the issue is fixed.

## Motivation

Previously, invalid `StateMachine` configurations could lead to a `NullPointerException` during simulation initialization. This change provides clear feedback to the user and avoids the crash.
