### PR TITLE
Add tag-triggered GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,256 @@
+name: Build and Release
+
+# Fires only when a version tag is pushed (e.g. v4.11).
+# See RELEASING.md for the full release process.
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+jobs:
+  # ── 1. Compile sources and produce JLS.jar ──────────────────────────────────
+  build-jar:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Derive version from tag
+        id: version
+        # Strip the leading 'v' from the tag name (v4.11 → 4.11)
+        run: echo "version=$(echo '${{ github.ref_name }}' | sed 's/^v//')" >> "$GITHUB_OUTPUT"
+
+      - name: Compile Java sources
+        run: |
+          mkdir -p bin
+          find src -name "*.java" > sources.txt
+          # Compile targeting Java 8 (Java 21 dropped --release 7 support)
+          javac -release 8 -cp lib/jhall.jar -d bin @sources.txt
+
+      - name: Copy resource files into output tree
+        run: |
+          # Eclipse treats resources/ as a source folder; copy non-Java files to bin/
+          find resources -type f ! -name "*.java" | while IFS= read -r f; do
+            dest="bin/${f#resources/}"
+            mkdir -p "$(dirname "$dest")"
+            cp "$f" "$dest"
+          done
+
+      - name: Package runnable JAR
+        run: |
+          mkdir -p staging
+          # Extract jhall.jar, then overlay compiled classes on top
+          cd staging && jar xf ../lib/jhall.jar && cd ..
+          cp -r bin/. staging/
+          # Remove any manifest baked into jhall.jar; ours will replace it
+          rm -f staging/META-INF/MANIFEST.MF
+          printf 'Main-Class: jls.JLS\n' > MANIFEST.MF
+          jar cfm releases/JLS.jar MANIFEST.MF -C staging .
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JLS-jar
+          path: releases/JLS.jar
+
+  # ── 2. Build macOS app-image via jpackage ───────────────────────────────────
+  #
+  # Code signing is optional. If the MACOS_CERTIFICATE and
+  # MACOS_CERTIFICATE_PASSWORD secrets are present the app is signed with the
+  # imported Developer ID certificate; otherwise it ships unsigned with a
+  # Gatekeeper note in the release body. See RELEASING.md for setup details.
+  build-macos:
+    runs-on: macos-latest
+    needs: build-jar
+    env:
+      HAS_CERT: ${{ secrets.MACOS_CERTIFICATE != '' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: JLS-jar
+          # Drop into the existing contents/ dir alongside fileIcon.icns
+          path: releases/macOS/contents
+
+      - name: Import Developer ID certificate into temporary keychain
+        if: env.HAS_CERT == 'true'
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 20)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Keep the keychain unlocked for the duration of the job (6 h)
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$MACOS_CERTIFICATE" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/jpackage
+
+          # Make the keychain searchable and allow codesign access without UI prompts
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Build macOS app image
+        working-directory: releases/macOS
+        env:
+          HAS_CERT: ${{ env.HAS_CERT }}
+        run: |
+          SIGN_ARGS=()
+          if [ "$HAS_CERT" = "true" ]; then
+            # Import step placed one cert in the temp keychain; jpackage picks it up automatically
+            SIGN_ARGS+=(--mac-sign)
+          fi
+
+          jpackage \
+            --type app-image \
+            --app-version "${{ needs.build-jar.outputs.version }}" \
+            --description "J(ava) Logic Simulator" \
+            --name "JLS" \
+            --icon resources/JLS.icns \
+            --resource-dir resources \
+            --mac-package-identifier "info.siever.JLS" \
+            --mac-package-name "JLS" \
+            --file-associations associations.properties \
+            --input contents \
+            --main-jar JLS.jar \
+            --main-class jls.JLS \
+            --mac-app-category education \
+            "${SIGN_ARGS[@]}"
+
+          zip -r JLS_macOS.zip JLS.app
+
+      - name: Remove temporary signing keychain
+        # Always clean up, even if the build step failed
+        if: always() && env.HAS_CERT == 'true'
+        run: security delete-keychain "$RUNNER_TEMP/build.keychain"
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JLS-macOS
+          path: releases/macOS/JLS_macOS.zip
+
+  # ── 3. Build Windows app-image via jpackage ─────────────────────────────────
+  build-windows:
+    runs-on: windows-latest
+    needs: build-jar
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: JLS-jar
+          # Drop into the existing contents/ dir alongside fileIcon.ico
+          path: releases/windows/contents
+
+      - name: Build Windows app image
+        working-directory: releases/windows
+        shell: pwsh
+        run: |
+          # Windows version strings require Major.Minor.Patch; append .0
+          jpackage `
+            --type app-image `
+            --app-version "${{ needs.build-jar.outputs.version }}.0" `
+            --description "J(ava) Logic Simulator" `
+            --name "JLS" `
+            --icon resources/JLS.ico `
+            --file-associations associations.properties `
+            --input contents `
+            --main-jar JLS.jar `
+            --main-class jls.JLS
+          Compress-Archive -Path JLS -DestinationPath JLS_windows.zip
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JLS-windows
+          path: releases/windows/JLS_windows.zip
+
+  # ── 4. Publish GitHub Release with all three assets ─────────────────────────
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-jar, build-macos, build-windows]
+    permissions:
+      contents: write
+    env:
+      SIGNED: ${{ secrets.MACOS_CERTIFICATE != '' }}
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release (signed macOS build)
+        if: env.SIGNED == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "JLS ${{ needs.build-jar.outputs.version }}"
+          body: |
+            ## Downloads
+
+            | File | Description |
+            |------|-------------|
+            | `JLS.jar` | Cross-platform runnable JAR (requires Java 8+) |
+            | `JLS_macOS.zip` | macOS application bundle — signed with Developer ID; unzip and drag JLS.app to Applications |
+            | `JLS_windows.zip` | Windows application bundle — unzip and run `JLS\JLS.exe` |
+          files: |
+            artifacts/JLS-jar/JLS.jar
+            artifacts/JLS-macOS/JLS_macOS.zip
+            artifacts/JLS-windows/JLS_windows.zip
+
+      - name: Create GitHub Release (unsigned macOS build)
+        if: env.SIGNED == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "JLS ${{ needs.build-jar.outputs.version }}"
+          body: |
+            ## Downloads
+
+            | File | Description |
+            |------|-------------|
+            | `JLS.jar` | Cross-platform runnable JAR (requires Java 8+) |
+            | `JLS_macOS.zip` | macOS application bundle — unzip and drag JLS.app to Applications |
+            | `JLS_windows.zip` | Windows application bundle — unzip and run `JLS\JLS.exe` |
+
+            > **macOS note:** This build is not code-signed. On first launch, right-click
+            > JLS.app and choose **Open** to allow Gatekeeper to run it.
+          files: |
+            artifacts/JLS-jar/JLS.jar
+            artifacts/JLS-macOS/JLS_macOS.zip
+            artifacts/JLS-windows/JLS_windows.zip

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,146 @@
+# Releasing JLS
+
+Every release is triggered by pushing a version tag. The GitHub Actions workflow
+then builds three artifacts automatically and publishes them as a GitHub Release:
+
+| Artifact | Description |
+|----------|-------------|
+| `JLS.jar` | Cross-platform runnable JAR (requires Java 8+) |
+| `JLS_macOS.zip` | macOS application bundle (via jpackage, bundled JRE) |
+| `JLS_windows.zip` | Windows application bundle (via jpackage, bundled JRE) |
+
+---
+
+## How to publish a release
+
+### 1. Update the version number in source
+
+Edit [`src/jls/JLSInfo.java`](src/jls/JLSInfo.java) and increment `vers` and/or
+`release` as appropriate:
+
+```java
+public static final int vers    = 4;
+public static final int release = 11;   // ← bump this
+```
+
+Commit that change:
+
+```bash
+git add src/jls/JLSInfo.java
+git commit -m "Bump version to 4.11"
+git push
+```
+
+### 2. Create and push a matching version tag
+
+The tag name **must** match the version you set in step 1:
+
+```bash
+git tag v4.11
+git push origin v4.11
+```
+
+That push triggers the workflow. The tag becomes the release name; the workflow
+strips the leading `v` to produce the jpackage version string (`4.11`).
+
+### 3. Monitor the build
+
+Open the **Actions** tab in the GitHub repository. The workflow has four jobs:
+
+```
+build-jar ──┬── build-macos ──┐
+            └── build-windows ─┴── create-release
+```
+
+`build-macos` and `build-windows` run in parallel once the JAR is ready.
+Total build time is typically 10–15 minutes.
+
+### 4. Verify the release
+
+When the workflow finishes, a release named **JLS 4.11** appears on the
+[Releases page](https://github.com/bsiever/JLS/releases) with all three files
+attached.
+
+---
+
+## macOS code signing (optional but recommended)
+
+Without a Developer ID certificate, macOS Gatekeeper will block the app on
+first launch. Users can still right-click → **Open** to bypass the warning, but
+signing removes this friction and is required for notarization.
+
+### What you need
+
+- An Apple Developer Program membership.
+- A **Developer ID Application** certificate issued by Apple.
+
+### Step 1 — Export the certificate from Keychain Access
+
+1. Open **Keychain Access** on your Mac.
+2. In the **login** keychain, find the certificate named
+   **Developer ID Application: Your Name (TEAM_ID)**.
+3. Right-click it and choose **Export "Developer ID Application: …"**.
+4. Save it as a `.p12` file and set a strong export password when prompted.
+
+### Step 2 — Base64-encode the .p12 file
+
+```bash
+base64 -i /path/to/certificate.p12 | pbcopy
+```
+
+This copies the base64 string to the clipboard.
+
+### Step 3 — Add secrets to the GitHub repository
+
+In the repository go to **Settings → Secrets and variables → Actions → New
+repository secret** and add the following two secrets:
+
+| Secret name | Value |
+|-------------|-------|
+| `MACOS_CERTIFICATE` | The base64 string from step 2 |
+| `MACOS_CERTIFICATE_PASSWORD` | The export password you set in step 1 |
+
+> **Do not commit the .p12 file or the password to the repository.**
+
+### Step 4 — Push a new release tag
+
+That's it. On the next tag push the workflow detects that `MACOS_CERTIFICATE`
+is set, imports the certificate into a temporary keychain on the macOS runner,
+passes `--mac-sign` to jpackage, and deletes the keychain when done.
+
+The release body will confirm whether the macOS build is signed.
+
+### How the signing works in the workflow
+
+The relevant steps in `.github/workflows/release.yml` are:
+
+1. **Import Developer ID certificate into temporary keychain** — decodes the
+   base64 secret, creates a short-lived keychain in `$RUNNER_TEMP`, imports the
+   `.p12`, and grants `codesign` and `jpackage` access without UI prompts.
+2. **Build macOS app image** — calls jpackage with `--mac-sign` when the
+   certificate is present. jpackage locates the single Developer ID certificate
+   in the temporary keychain automatically.
+3. **Remove temporary signing keychain** — runs unconditionally (even on build
+   failure) to ensure the certificate is not left on the runner.
+
+### Notarization (future step)
+
+Signing satisfies Gatekeeper for direct downloads. For full notarization
+(required for distribution outside the Mac App Store without any Gatekeeper
+prompt) you additionally need to submit the signed `.app` to Apple's notary
+service using `xcrun notarytool`. This can be added as an extra workflow step
+using the secrets `APPLE_ID`, `APPLE_TEAM_ID`, and an app-specific password.
+
+---
+
+## Deleting or re-running a release
+
+To redo a release for an existing tag:
+
+1. Delete the release from the GitHub Releases page (keep or delete the tag).
+2. Delete the tag locally and remotely if you want to re-push it:
+   ```bash
+   git tag -d v4.11
+   git push origin :refs/tags/v4.11
+   ```
+3. Re-push the tag to trigger a fresh build.


### PR DESCRIPTION
## What changed

Adds automated release infrastructure so that pushing a version tag (e.g. `v4.11`) to `master` builds and publishes a GitHub Release with three artifacts — no manual Eclipse exports required.

### New files

| File | Purpose |
|------|---------|
| `.github/workflows/release.yml` | GitHub Actions workflow |
| `RELEASING.md` | Step-by-step release and code-signing guide |

### Workflow overview

```
build-jar ──┬── build-macos ──┐
            └── build-windows ─┴── create-release
```

**`build-jar`** (ubuntu-latest)
- Compiles all Java sources with `javac --release 8` (Java 21 dropped `--release 7`)
- Extracts `lib/jhall.jar` and merges it with the compiled classes
- Copies the `resources/` source folder (JavaHelp content, icons) into the JAR
- Uploads `JLS.jar` as a workflow artifact

**`build-macos`** / **`build-windows`** (run in parallel)
- Download the JAR into the existing `releases/{platform}/contents/` directory alongside the file-association icons
- Run `jpackage --type app-image` using the JDK 21 bundled by `actions/setup-java` (no need to commit or download a 200 MB JRE)
- Zip the resulting app-image

**`create-release`**
- Creates a GitHub Release named `JLS <version>` using the tag as-is
- Attaches all three artifacts

### macOS code signing

Signing is **optional and additive** — the workflow checks whether the `MACOS_CERTIFICATE` secret exists and behaves accordingly:

- **Secret present:** imports the Developer ID `.p12` into a temporary keychain, passes `--mac-sign` to jpackage, deletes the keychain on completion (even on failure). Release body says "signed".
- **Secret absent:** builds unsigned. Release body includes a Gatekeeper right-click workaround note.

`RELEASING.md` documents how to export the certificate, base64-encode it, and add the two required secrets (`MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PASSWORD`).

## Reviewer notes

- The trigger is `push: tags: v[0-9]*` — ordinary commits to `master` do **not** create releases. The full release process is: bump `vers`/`release` in `JLSInfo.java` → commit → `git tag vX.Y` → `git push origin vX.Y`.
- Windows jpackage requires a three-component version string; `.0` is appended automatically (`4.11` → `4.11.0`).
- `--mac-sign` without `--mac-signing-key-user-name` is intentional: since only one cert is imported into the temp keychain, jpackage finds it automatically without needing a third secret.
- Repo **Settings → Actions → General → Workflow permissions** must be set to **Read and write** (or the default `GITHUB_TOKEN` must have `contents: write`) for the release step to succeed.