### PR TITLE
Overlap Performance (Minimal)

### DIFF
--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2837,11 +2837,15 @@ public abstract class SimpleEditor extends JPanel {
 				}
 			}*/
 
+						untouchAll(); // may have moved and stopped touching
 
 						// check every element in the selected set
 						for (Element sel : selected) {
 
-							// check against every element in the circuit
+							// only one element and selected element need to be intersecting to cause a problem
+							boolean anyIntersection = false;
+
+							// check against every unselected element in the circuit
 							for (Element el : circuit.getElements()) {
 
 								// ignore elements in the selected set
@@ -2850,6 +2854,7 @@ public abstract class SimpleEditor extends JPanel {
 
 								// check simple overlap of areas
 								if (sel.intersects(el)) {
+									anyIntersection = true;
 
 									// no overlap if possible connection,
 									boolean ok = false;
@@ -2925,15 +2930,13 @@ public abstract class SimpleEditor extends JPanel {
 									}
 
 									// selected is not a wire end
-									else {
+									// if not a wire end, ignore
+									else if (el instanceof WireEnd) {
+
+										WireEnd end = (WireEnd)el;
 
 										// put to wire end
 										for (Put put : sel.getAllPuts()) {
-
-											// if not a wire end, ignore
-											if (!(el instanceof WireEnd))
-												continue;
-											WireEnd end = (WireEnd)el;
 
 											// if don't line up, ignore
 											if (put.getX() != end.getX() || put.getY() != end.getY()) {
@@ -2971,52 +2974,59 @@ public abstract class SimpleEditor extends JPanel {
 										return true;
 									}
 								}
+							}
 
-								// no intersection, but wires may be overlapping wire ends
-								// or puts might line up
-								else {
+							// no intersection, but wires may be overlapping wire ends
+							// or puts might line up
+							if (!anyIntersection) {
 
-									// see if wires connected to a wire end dragged onto wire ends
-									if (sel instanceof WireEnd) {
-										WireEnd end = (WireEnd)sel;
-										for (Wire wire : end.getWires()) {
-											for (Element elm : circuit.getElements()) {
-												if (sel == elm)
-													continue;
-												if (!(elm instanceof WireEnd)) {
-													continue;
-												}
-												WireEnd otherEnd = (WireEnd)elm;
-												if (wire.touches(otherEnd)) {
-													overlapMessage = "overlap";
-													untouchAll();
-													return true;
-												}
+								// see if wires connected to a wire end dragged onto wire ends
+								if (sel instanceof WireEnd) {
+									WireEnd end = (WireEnd)sel;
+									for (Wire wire : end.getWires()) {
+										for (Element el : circuit.getElements()) {
+											if (sel == el)
+												continue;
+											if (!(el instanceof WireEnd)) {
+												continue;
+											}
+											WireEnd otherEnd = (WireEnd)el;
+											if (wire.touches(otherEnd)) {
+												overlapMessage = "overlap";
+												untouchAll();
+												return true;
 											}
 										}
 									}
+								}
 
-									// see if wires connected to puts dragged onto wire ends
-									for (Put p : sel.getAllPuts()) {
-										if (p.isAttached()) {
-											Wire wire = p.getWireEnd().getOnlyWire();
-											for (Element elm : circuit.getElements()) {
-												if (sel == elm)
-													continue;
-												if (!(elm instanceof WireEnd)) {
-													continue;
-												}
-												WireEnd otherEnd = (WireEnd)elm;
-												if (wire.touches(otherEnd)) {
-													overlapMessage = "overlap";
-													untouchAll();
-													return true;
-												}
+								// see if wires connected to puts dragged onto wire ends
+								for (Put p : sel.getAllPuts()) {
+									if (p.isAttached()) {
+										Wire wire = p.getWireEnd().getOnlyWire();
+										for (Element el : circuit.getElements()) {
+											if (sel == el)
+												continue;
+											if (!(el instanceof WireEnd)) {
+												continue;
+											}
+											WireEnd otherEnd = (WireEnd)el;
+											if (wire.touches(otherEnd)) {
+												overlapMessage = "overlap";
+												untouchAll();
+												return true;
 											}
 										}
 									}
+								}
 
-									// check all put combinations
+								// check all put combinations
+								for (Element el : circuit.getElements()) {
+
+									// ignore elements in the selected set
+									if (selected.contains(el))
+										continue;
+
 									for (Put p1 : sel.getAllPuts()) {
 										for (Put p2 : el.getAllPuts()) {
 

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2842,7 +2842,7 @@ public abstract class SimpleEditor extends JPanel {
 						// check every element in the selected set
 						for (Element sel : selected) {
 
-							// only one element and selected element need to be intersecting to cause a problem
+							// only one element needs to be intersecting the selected element to count as overlap
 							boolean anyIntersection = false;
 
 							// check against every element in the circuit

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2845,7 +2845,7 @@ public abstract class SimpleEditor extends JPanel {
 							// only one element and selected element need to be intersecting to cause a problem
 							boolean anyIntersection = false;
 
-							// check against every unselected element in the circuit
+							// check against every element in the circuit
 							for (Element el : circuit.getElements()) {
 
 								// ignore elements in the selected set


### PR DESCRIPTION
While this does not improve the overall algorithm of identifying what is overlapping what, it improves the overlap performance significantly through just one change that doesn't rely on structure implementations or hardware expectations.

The current implementation iterates over every selected element, checks against each unselected element, and then WITHIN each of those iterations, if there isn't an intersection, it iterates over *every unselected element*, again, **within the "every unselected element" loop**, to check a condition that gets cancelled out if an *upcoming* element is intersecting. This transforms a roughly $O(n^2)$ operation into an $O(n^3)$ operation that can be avoided by simply keeping track of whether there was an intersection at all and performing the "no intersections" branch all in one go.

The proposed solution does this: keeping track of whether a selected element is intersecting any unselected element and only performing the extra checks, once per selected element, if there are no intersections.